### PR TITLE
Remove `INIT_PATH`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,23 +2,8 @@ import deepEqual from 'deep-equal'
 
 // Constants
 
-const INIT_PATH = '@@router/INIT_PATH'
 export const UPDATE_PATH = '@@router/UPDATE_PATH'
 const SELECT_STATE = state => state.routing
-
-// Action creators
-
-function initPath(path, state) {
-  return {
-    type: INIT_PATH,
-    payload: {
-      path: path,
-      state: state,
-      replace: false,
-      avoidRouterUpdate: true
-    }
-  }
-}
 
 export function pushPath(path, state, { avoidRouterUpdate = false } = {}) {
   return {
@@ -54,7 +39,7 @@ let initialState = {
 }
 
 function update(state=initialState, { type, payload }) {
-  if(type === INIT_PATH || type === UPDATE_PATH) {
+  if(type === UPDATE_PATH) {
     return Object.assign({}, state, {
       path: payload.path,
       changeId: state.changeId + (payload.avoidRouterUpdate ? 0 : 1),
@@ -128,7 +113,8 @@ export function syncReduxAndRouter(history, store, selectRouterState = SELECT_ST
       // trigger an unnecessary `pushState` on load
       lastRoute = initialState
 
-      store.dispatch(initPath(route.path, route.state))
+      const method = location.action === 'REPLACE' ? replacePath : pushPath;
+      store.dispatch(method(route.path, route.state, { avoidRouterUpdate: true }));
     } else if(!locationsAreEqual(getRouterState(), route)) {
       // The above check avoids dispatching an action if the store is
       // already up-to-date

--- a/src/index.js
+++ b/src/index.js
@@ -113,8 +113,7 @@ export function syncReduxAndRouter(history, store, selectRouterState = SELECT_ST
       // trigger an unnecessary `pushState` on load
       lastRoute = initialState
 
-      const method = location.action === 'REPLACE' ? replacePath : pushPath;
-      store.dispatch(method(route.path, route.state, { avoidRouterUpdate: true }));
+      store.dispatch(pushPath(route.path, route.state, { avoidRouterUpdate: true }));
     } else if(!locationsAreEqual(getRouterState(), route)) {
       // The above check avoids dispatching an action if the store is
       // already up-to-date


### PR DESCRIPTION
No tests fail, so not sure we need this constant? We should either add a failing test or remove it.

The use case for removing this is receiving the initial URL when using `UPDATE_PATH`, e.g. #96.

(So the functional difference is: do we notify the initial route or only changes from the initial route?)