### PR TITLE
Fix double update on history.pushState

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -92,6 +92,7 @@ function syncReduxAndRouter(history, store, selectRouterState = SELECT_STATE) {
   // history update. It's possible for this to happen when something
   // reloads the entire app state such as redux devtools.
   let lastRoute = undefined
+  let historyUpdate = false
 
   if(!getRouterState()) {
     throw new Error(
@@ -132,6 +133,7 @@ function syncReduxAndRouter(history, store, selectRouterState = SELECT_STATE) {
     } else if(!locationsAreEqual(getRouterState(), route)) {
       // The above check avoids dispatching an action if the store is
       // already up-to-date
+      historyUpdate = true;
       const method = location.action === 'REPLACE' ? replacePath : pushPath
       store.dispatch(method(route.path, route.state, { avoidRouterUpdate: true }))
     }
@@ -139,6 +141,11 @@ function syncReduxAndRouter(history, store, selectRouterState = SELECT_STATE) {
 
   const unsubscribeStore = store.subscribe(() => {
     let routing = getRouterState()
+
+    if (historyUpdate) {
+      historyUpdate = false;
+      return;
+    }
 
     // Only trigger history update if this is a new change or the
     // location has changed.

--- a/test/createTests.js
+++ b/test/createTests.js
@@ -515,6 +515,22 @@ module.exports = function createTests(createHistory, name, reset = defaultReset)
 
         storeUnsubscribe()
       })
+
+      it('only triggers once when updating path via history push', () => {
+        let count = 0
+        const historyUnsubscribe = history.listen(location => {
+          // excluding the inital url
+          if (location.pathname !== '/') {
+            count++
+          }
+        })
+
+        history.pushState(null, '/bar')
+
+        expect(count).toEqual(1)
+
+        historyUnsubscribe()
+      })
     })
 
     it('handles basename history option', () => {

--- a/test/createTests.js
+++ b/test/createTests.js
@@ -517,17 +517,13 @@ module.exports = function createTests(createHistory, name, reset = defaultReset)
       })
 
       it('only triggers once when updating path via history push', () => {
-        let count = 0
+        const updates = []
         const historyUnsubscribe = history.listen(location => {
-          // excluding the inital url
-          if (location.pathname !== '/') {
-            count++
-          }
+          updates.push(location.pathname);
         })
 
         history.pushState(null, '/bar')
-
-        expect(count).toEqual(1)
+        expect(updates).toEqual(['/', '/bar'])
 
         historyUnsubscribe()
       })

--- a/test/createTests.js
+++ b/test/createTests.js
@@ -516,16 +516,30 @@ module.exports = function createTests(createHistory, name, reset = defaultReset)
         storeUnsubscribe()
       })
 
-      it('only triggers once when updating path via history push', () => {
+      it('only triggers history once when updating path via history push', () => {
         const updates = []
         const historyUnsubscribe = history.listen(location => {
           updates.push(location.pathname);
         })
 
         history.pushState(null, '/bar')
-        expect(updates).toEqual(['/', '/bar'])
+        history.pushState(null, '/baz')
+        expect(updates).toEqual(['/', '/bar', '/baz'])
 
         historyUnsubscribe()
+      })
+
+      it('only triggers store once when updating path via history push', () => {
+        const updates = []
+        const storeUnsubscribe = store.subscribe(() => {
+          updates.push(store.getState().routing.path);
+        })
+
+        history.pushState(null, '/bar')
+        history.pushState(null, '/baz')
+        expect(updates).toEqual(['/bar', '/baz'])
+
+        storeUnsubscribe()
       })
     })
 


### PR DESCRIPTION
Not the nicest tests or the nicest implementation, but a suggestion for how to handle the double updating reported in #108.

(Of course, if we end up going in this direction I'll add in some comments and tune the tests)

Anyone else got ideas that don't break any of the other tests? I'll try to play around with it a bit more too.