### PR TITLE
Failing test for `avoidRouterUpdate`

### DIFF
--- a/test/createTests.js
+++ b/test/createTests.js
@@ -356,6 +356,19 @@ module.exports = function createTests(createHistory, name, reset = defaultReset)
         })
       })
 
+      it('does not sync redux -> router if `avoidRouterUpdate`', () => {
+        const updates = []
+        const historyUnsubscribe = history.listen(location => {
+          updates.push(location.pathname)
+        })
+
+        store.dispatch(pushPath('/foo', null, { avoidRouterUpdate: true }))
+
+        expect(updates).toEqual([ '/' ])
+
+        historyUnsubscribe()
+      });
+
       it('updates the router even if path is the same', () => {
         const updates = []
         const historyUnsubscribe = history.listen(location => {

--- a/test/createTests.js
+++ b/test/createTests.js
@@ -356,7 +356,7 @@ module.exports = function createTests(createHistory, name, reset = defaultReset)
         })
       })
 
-      it('does not sync redux -> router if `avoidRouterUpdate`', () => {
+      it('does not update `history` if `avoidRouterUpdate`', () => {
         const updates = []
         const historyUnsubscribe = history.listen(location => {
           updates.push(location.pathname)


### PR DESCRIPTION
Hm, as far as I can see `avoidRouterUpdate` is actually broken:

> Error: Expected [ '/', '/foo' ] to equal [ '/' ]

This api is causing us a lot of complexity — should we just remove it? Can't you basically "fake" the same thing using `replacePath`?

(The docs mention `forceRefresh`, but I've never looked at it, so don't know if that's something that will break? Does the value gained outweigh the complexity?)

I'll keep playing around with the code and tests to try to find a solution.