### PR TITLE
Slight change to error message

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -95,8 +95,8 @@ export function syncReduxAndRouter(history, store, selectRouterState = SELECT_ST
 
   if(!getRouterState()) {
     throw new Error(
-      'Cannot sync router: route state does not exist. Did you ' +
-      'install the routing reducer?'
+      'Cannot sync router: route state does not exist (`state.routing` by default). ' +
+      'Did you install the routing reducer?'
     )
   }
 


### PR DESCRIPTION
Hi,

I was trying out the library and caught an error (due to a misunderstanding on my part).

```
Cannot sync router: route state does not exist. Did you install the routing reducer?
```

I thought I had installed the reducer in the right place, but erroneously placed it in `state.route` (and misinterpreted the error message to be leading me to `state.route`).

This PR adds a little bit more specificity to the error message.

No hard feelings if you think this might make error messages too wordy. Most of all, *thanks for making a routing library that is so simple I can actually debug my problems*!