### PR TITLE
Use middleware to synchronize store to history

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,3 @@
 {
-    "presets": ["es2015"],
-    "plugins": ["transform-object-assign"]
+    "presets": ["es2015", "stage-2"]
 }

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "babel-core": "^6.2.1",
     "babel-eslint": "^4.1.6",
     "babel-loader": "^6.2.0",
-    "babel-plugin-transform-object-assign": "^6.0.14",
     "babel-preset-es2015": "^6.1.2",
+    "babel-preset-stage-2": "^6.3.13",
     "eslint": "^1.10.3",
     "eslint-config-rackt": "^1.1.1",
     "expect": "^1.13.0",
@@ -64,8 +64,5 @@
     "redux": "^3.0.4",
     "redux-devtools": "^2.1.5",
     "webpack": "^1.12.9"
-  },
-  "dependencies": {
-    "deep-equal": "^1.0.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -78,16 +78,21 @@ export function syncHistory(history) {
       const { location: initialLocation } = getRouterState()
 
       unsubscribeStore = store.subscribe(() => {
-        // If we're resetting to the beginning, use the saved values.
-        const storeLocation = getRouterState().location
-        const location = storeLocation || initialLocation
+        const { location } = getRouterState()
 
+        // If we're resetting to the beginning, use the saved initial value. We
+        // need to dispatch a new action at this point to populate the store
+        // appropriately.
+        if (!location) {
+          history.transitionTo(initialLocation)
+          return
+        }
+
+        // Otherwise, if we need to update the history location, do so without
+        // dispatching a new action, as we're just bringing history in sync
+        // with the store.
         if (location.key !== currentKey) {
-          // If there already is a location in the store, then don't dispatch
-          // an action from the history listener; otherwise do so in order to
-          // populate the store.
-          syncing = !!storeLocation
-
+          syncing = true
           history.transitionTo(location)
           syncing = false
         }


### PR DESCRIPTION
Per https://github.com/rackt/redux-simple-router/pull/129#issuecomment-167392040.

Fixes https://github.com/rackt/redux-simple-router/issues/108.

The idea is basically - keep unidirectional data flow for updates, most of the time. This works in most cases, but it breaks replay, since the actions in some sense aren't pure. That's fine, though - we can restrict the store observer to _only_ handle the replay case (and potentially not even use it otherwise).