### PR TITLE
Export action creators in namespace. Add go, goBack, goForward

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,15 +12,13 @@ function transition(method) {
   })
 }
 
-const push = transition('push')
-const replace = transition('replace')
-
 export const routeActions = {
-  push,
-  replace
+  push: transition('push'),
+  replace: transition('replace'),
+  go: transition('go'),
+  goBack: transition('goBack'),
+  goForward: transition('goForward')
 }
-
-// TODO: Add go, goBack, goForward.
 
 function updateLocation(location) {
   return {

--- a/src/index.js
+++ b/src/index.js
@@ -12,8 +12,13 @@ function transition(method) {
   })
 }
 
-export const push = transition('push')
-export const replace = transition('replace')
+const push = transition('push')
+const replace = transition('replace')
+
+export const routeActions = {
+  push,
+  replace
+}
 
 // TODO: Add go, goBack, goForward.
 

--- a/test/createTests.js
+++ b/test/createTests.js
@@ -2,7 +2,7 @@
 
 import expect from 'expect'
 import {
-  push, replace, TRANSITION, UPDATE_LOCATION, routeReducer, syncHistory
+  routeActions, TRANSITION, UPDATE_LOCATION, routeReducer, syncHistory
 } from '../src/index'
 import { applyMiddleware, createStore, combineReducers, compose } from 'redux'
 import { devTools } from 'redux-devtools'
@@ -43,47 +43,53 @@ function createSyncedHistoryAndStore(createHistory) {
 
 const defaultReset = () => {}
 
+const { push, replace } = routeActions
+
 module.exports = function createTests(createHistory, name, reset = defaultReset) {
   describe(name, () => {
 
     beforeEach(reset)
 
-    describe('push', () => {
-      it('creates actions', () => {
-        expect(push('/foo')).toEqual({
-          type: TRANSITION,
-          method: 'push',
-          arg: '/foo'
-        })
+    describe('routeActions', () => {
 
-        expect(push({ pathname: '/foo', state: { the: 'state' } })).toEqual({
-          type: TRANSITION,
-          method: 'push',
-          arg: {
-            pathname: '/foo',
-            state: { the: 'state' }
-          }
+      describe('push', () => {
+        it('creates actions', () => {
+          expect(push('/foo')).toEqual({
+            type: TRANSITION,
+            method: 'push',
+            arg: '/foo'
+          })
+
+          expect(push({ pathname: '/foo', state: { the: 'state' } })).toEqual({
+            type: TRANSITION,
+            method: 'push',
+            arg: {
+              pathname: '/foo',
+              state: { the: 'state' }
+            }
+          })
         })
       })
-    })
 
-    describe('replace', () => {
-      it('creates actions', () => {
-        expect(replace('/foo')).toEqual({
-          type: TRANSITION,
-          method: 'replace',
-          arg: '/foo'
-        })
+      describe('replace', () => {
+        it('creates actions', () => {
+          expect(replace('/foo')).toEqual({
+            type: TRANSITION,
+            method: 'replace',
+            arg: '/foo'
+          })
 
-        expect(replace({ pathname: '/foo', state: { the: 'state' } })).toEqual({
-          type: TRANSITION,
-          method: 'replace',
-          arg: {
-            pathname: '/foo',
-            state: { the: 'state' }
-          }
+          expect(replace({ pathname: '/foo', state: { the: 'state' } })).toEqual({
+            type: TRANSITION,
+            method: 'replace',
+            arg: {
+              pathname: '/foo',
+              state: { the: 'state' }
+            }
+          })
         })
       })
+
     })
 
     describe('routeReducer', () => {

--- a/test/createTests.js
+++ b/test/createTests.js
@@ -43,7 +43,7 @@ function createSyncedHistoryAndStore(createHistory) {
 
 const defaultReset = () => {}
 
-const { push, replace } = routeActions
+const { push, replace, go, goBack, goForward } = routeActions
 
 module.exports = function createTests(createHistory, name, reset = defaultReset) {
   describe(name, () => {
@@ -86,6 +86,36 @@ module.exports = function createTests(createHistory, name, reset = defaultReset)
               pathname: '/foo',
               state: { the: 'state' }
             }
+          })
+        })
+      })
+
+      describe('go', () => {
+        it('creates actions', () => {
+          expect(go(1)).toEqual({
+            type: TRANSITION,
+            method: 'go',
+            arg: 1
+          })
+        })
+      })
+
+      describe('goBack', () => {
+        it('creates actions', () => {
+          expect(goBack()).toEqual({
+            type: TRANSITION,
+            method: 'goBack',
+            arg: undefined
+          })
+        })
+      })
+
+      describe('goForward', () => {
+        it('creates actions', () => {
+          expect(goForward()).toEqual({
+            type: TRANSITION,
+            method: 'goForward',
+            arg: undefined
           })
         })
       })


### PR DESCRIPTION
You now get to them via the `routeActions` export.
```js
import { routeActions } from 'redux-simple-router'
routeActions.push('/foo')
```
This makes binding just the action creators in your `connect`s really easy:
```js
@connect(
  someSelector,
  dispatch => ({ router: bindActionCreators({ routeActions }, dispatch) })
)
class FooBar extends Component {
  handleClick = () => {
    this.props.router.push("/foo")
  }
}
```