### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ Call this on the middleware returned from `syncHistory` to start the syncing pro
 
 Supply an optional function `selectRouterState` to customize where to find the router state on your app state. It defaults to `state => state.routing`, so you would install the reducer under the name "routing". Feel free to change this to whatever you like.
 
+#### `ReduxMiddleware.unsubscribe()`
+
+Call this on the middleware returned from `syncHistory` to stop the syncing process set up by `syncHistoryToStore`. 
+
 #### `routeReducer`
 
 A reducer function that keeps track of the router state. You must to add this reducer to your app reducers when creating the store.

--- a/README.md
+++ b/README.md
@@ -140,11 +140,6 @@ A reducer function that keeps track of the router state. You must to add this re
 
 An action type that you can listen for in your reducers to be notified of route updates.
 
-#### `push(nextLocation: LocationDescriptor)`
-
-An action creator that you can use to update the current URL and update the browser history.
-The LocationDescriptor parameter can be either as string with the path or a [LocationDescriptorObject](https://github.com/rackt/history/blob/v1.17.0/docs/Glossary.md#locationdescriptor) if you need more detailed control.
-
 #### `routeActions`
 
 An object that contains all the actions creators you can use to manipulate history:

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Examples from the community:
 * [tj/frontend-boilerplate](https://github.com/tj/frontend-boilerplate)
 * [bdefore/universal-redux](https://github.com/bdefore/universal-redux) - npm package for universally rendered redux applications
 * [yangli1990/react-redux-isomorphic](https://github.com/yangli1990/Isomorphic-Universal-React-Template) - boilerplate for universal redux and redux-simple-router
+* [StevenIseki/redux-simple-router-example](https://github.com/StevenIseki/redux-simple-router-example)
 
 _Have an example to add? Send us a PR!_
 

--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ An object that contains all the actions creators you can use to manipulate histo
 
 * `push(nextLocation: LocationDescriptor)`
 * `replace(nextLocation: LocationDescriptor)`
-* `go(nextLocation: LocationDescriptor)`
-* `goForward(nextLocation: LocationDescriptor)`
-* `goBack(nextLocation: LocationDescriptor)`
+* `go(n: number)`
+* `goForward()`
+* `goBack()`
 
 The most common action is to push a new URL via `routeActions.push(...)`. These all directly call the analogous [history methods](https://github.com/rackt/history/blob/master/docs/GettingStarted.md#navigation).

--- a/src/index.js
+++ b/src/index.js
@@ -67,11 +67,6 @@ export function syncHistory(history) {
 
       const { method, arg } = action
       history[method](arg)
-
-      // FIXME: Is it correct to swallow the TRANSITION action here and replace
-      // it with UPDATE_LOCATION instead? We could also use the same type in
-      // both places instead and just set the location on the action.
-      //return next(updateLocation(location));
     }
   }
 


### PR DESCRIPTION
added my simple redux-simple-router example. 
It is based on the basic example but has additional
- css modules
- express
- isomorphic-fetch
- webpack-dev-server
- redux-logger

It is a simple app which lists all react components and shows their readme's similar to https://www.npmjs.com