### PR TITLE
Include any previous state in routeReducer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ export function routeReducer(state = initialState, { type, location }) {
     return state
   }
 
-  return { location }
+  return { ...state, location }
 }
 
 // Syncing


### PR DESCRIPTION
This was wiping out state when not using `combineReducers` or reducing this reducer with others.