### PR TITLE
rename syncHistoryToStore to listenForReplays

### DIFF
--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -31,7 +31,7 @@ const finalCreateStore = compose(
   DevTools.instrument()
 )(createStore);
 const store = finalCreateStore(reducer);
-middleware.syncHistoryToStore(store);
+middleware.listenForReplays(store);
 
 ReactDOM.render(
   <Provider store={store}>

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ export function syncHistory(history) {
     }
   }
 
-  middleware.syncHistoryToStore =
+  middleware.listenForReplays =
     (store, selectRouterState = SELECT_STATE) => {
       const getRouterState = () => selectRouterState(store.getState())
       const { location: initialLocation } = getRouterState()

--- a/test/createTests.js
+++ b/test/createTests.js
@@ -185,7 +185,7 @@ module.exports = function createTests(createHistory, name, reset = defaultReset)
         }))
         devToolsStore = store.liftedStore
 
-        middleware.syncHistoryToStore(store)
+        middleware.listenForReplays(store)
       })
 
       afterEach(() => {


### PR DESCRIPTION
@timdorr mentioned in https://github.com/rackt/redux-simple-router/issues/189#issuecomment-171524092 that this function is purely for devtools. I sort of forgot that it is completely for devtools, and because if this, I think we should rename the function. I propose `listenForReplays`, given that that's the usual use case. It might not be a replay that triggers it, but that's not a huge deal, it's something *like* a replay.

We can also mark this optional; people that don't use the devtools don't need it.