### PR TITLE
fix example by updating to 2.0.3

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -8,7 +8,7 @@
     "react-redux": "^4.0.0",
     "react-router": "^1.0.0",
     "redux": "^3.0.4",
-    "redux-simple-router": "2.0.3"
+    "redux-simple-router": "^2.0.3"
   },
   "devDependencies": {
     "babel-core": "^6.1.21",

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -8,7 +8,7 @@
     "react-redux": "^4.0.0",
     "react-router": "^1.0.0",
     "redux": "^3.0.4",
-    "redux-simple-router": "2.0.1"
+    "redux-simple-router": "2.0.3"
   },
   "devDependencies": {
     "babel-core": "^6.1.21",


### PR DESCRIPTION
Fixes fatal runtime error `Uncaught TypeError: middleware.listenForReplays is not a function`.